### PR TITLE
No resource or method named yum_key

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,14 +56,11 @@ when 'debian'
 
 when 'rhel'
 
-  yum_key 'oracle-virtualbox' do
-    url 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
-    action :add
-  end
-
   yum_repository 'oracle-virtualbox' do
     description 'Oracle Linux / RHEL / CentOS-$releasever / $basearch - VirtualBox'
     url 'http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch'
+    gpgkey 'https://www.virtualbox.org/download/oracle_vbox.asc'
+    action :create
   end
 
   package "VirtualBox-#{node['virtualbox']['version']}"


### PR DESCRIPTION
===============================================================================
  Recipe Compile Error in /var/chef/cache/cookbooks/virtualbox/recipes/default.rb  ===============================================================================
  
  NoMethodError
  -------------
  No resource or method named `yum_key' for `Chef::Recipe "default"'
  
  Cookbook Trace:
  ---------------
    /var/chef/cache/cookbooks/virtualbox/recipes/default.rb:59:in `from_file'
  
  Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/virtualbox/recipes/default.rb:
  
   52:    end
   53:  
   54:    package "virtualbox-#{node['virtualbox']['version']}"
   55:    package 'dkms'
   56:  
   57:  when 'rhel'
   58:  
   59>>   yum_key 'oracle-virtualbox' do
   60:      url 'http://download.virtualbox.org/virtualbox/debian/oracle_vbox.asc'
   61:      action :add
   62:    end
   63:  
   64:    yum_repository 'oracle-virtualbox' do
   65:      description 'Oracle Linux / RHEL / CentOS-$releasever / $basearch - VirtualBox'
   66:      url 'http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch'
   67:    end
   68:  
